### PR TITLE
Pass `attributes` to strict/default setter fns

### DIFF
--- a/src/arguments.js
+++ b/src/arguments.js
@@ -85,9 +85,9 @@ export function ensureArray(maybeArray) {
 /**
  * Resolves any key values of the given object into their return values.
  */
-export function resolveObject(object) {
+export function resolveObject(object, ...args) {
   return mapValues(object, (value, key) =>
-    isFunction(value) ? value(object) : value
+    isFunction(value) ? value(...args) : value
   );
 }
 
@@ -98,19 +98,19 @@ export function resolveObject(object) {
  * @returns {Object}
  *   Target object, or copy of target object with defaults applied.
  */
-export function defaultsResolved(target, source) {
-  const required = omit(source, objectKeys(target));
-  if (isEmpty(required)) {
-    return target || {};
+export function defaultsResolved(target = {}, source, ...args) {
+  const defaults = omit(source, objectKeys(target));
+  if (isEmpty(defaults)) {
+    return target;
   }
-  const defaults = resolveObject(required);
-  return { ...defaults, ...target };
+  const resolved = resolveObject(defaults, ...args);
+  return { ...resolved, ...target };
 }
 
-export function assignResolved(target, source) {
+export function assignResolved(target = {}, source, ...args) {
   return isEmpty(source)
-    ? target || {}
-    : { ...target, ...resolveObject(source) };
+    ? target
+    : { ...target, ...resolveObject(source, ...args) };
 }
 
 export function keyValueToObject(key, value) {

--- a/src/mapper/forge.js
+++ b/src/mapper/forge.js
@@ -18,7 +18,9 @@ const methods = {
 
   _forgeOne(attributes) {
     const { defaultAttributes } = this.state;
-    return this.createRecord(defaultsResolved(attributes, defaultAttributes));
+    return this.createRecord(
+      defaultsResolved(attributes, defaultAttributes, attributes)
+    );
   }
 };
 

--- a/src/mapper/insert.js
+++ b/src/mapper/insert.js
@@ -89,8 +89,12 @@ const methods = {
       .flatten()
       .compact()
       .map(this.getAttributes, this)
-      .map(attributes => defaultsResolved(attributes, defaultAttributes))
-      .map(attributes => assignResolved(attributes, strictAttributes))
+      .map(attributes =>
+        defaultsResolved(attributes, defaultAttributes, attributes)
+      )
+      .map(attributes =>
+        assignResolved(attributes, strictAttributes, attributes)
+      )
       .map(this.attributesToColumns, this)
       .value();
 

--- a/src/mapper/update.js
+++ b/src/mapper/update.js
@@ -1,6 +1,6 @@
 import { isArray, isEmpty } from 'lodash/lang';
 import { map, size } from 'lodash/collection';
-import { values as objectValues } from 'lodash/object';
+import { values as objectValues, omit } from 'lodash/object';
 import { first } from 'lodash/array';
 import Promise from 'bluebird';
 
@@ -95,9 +95,12 @@ const methods = {
 
   getUpdateAttributes(record) {
     const idAttribute = this.requireState('idAttribute');
+    const attributes = this.getAttributes(record);
     const { strictAttributes } = this.state;
     return assignResolved(
-      this.omitAttributes(record, idAttribute), strictAttributes
+      omit(attributes, idAttribute),
+      strictAttributes,
+      attributes
     );
   },
 

--- a/tests/unit/arguments.js
+++ b/tests/unit/arguments.js
@@ -67,6 +67,7 @@ test('Arguments', t => {
   t.test('resolveObject', st => {
     st.deepEqual(resolveObject(), {});
     st.deepEqual(resolveObject({a: 'a', b: () => 'b'}), {a: 'a', b: 'b'});
+    st.deepEqual(resolveObject({a: 'a', b: a => a}, 'b'), {a: 'a', b: 'b'});
 
     st.end();
   });
@@ -92,6 +93,19 @@ test('Arguments', t => {
       {a: 'a', b: 'b'}
     );
 
+    function unnecessaryDefault() {
+      st.fail('defaultsResolved should not evaluate functions unnecessarily');
+    }
+    st.deepEqual(
+      defaultsResolved(
+        { a: 'a' },
+        { a: unnecessaryDefault, b: (v1, v2) => v1 + v2 },
+        'd', 'e'
+      ),
+      {a: 'a', b: 'de'},
+      `passes arguments to resolver function callbacks`
+    );
+
     st.end();
   });
 
@@ -112,6 +126,15 @@ test('Arguments', t => {
     st.deepEqual(assignResolved({b: 'b'}, {a: 'a'}), {a: 'a', b: 'b'});
     st.deepEqual(assignResolved({b: 'b'}, {b: () => 'a'}), {b: 'a'});
 
+    st.deepEqual(
+      assignResolved(
+        { a: 'a' },
+        { a: (v1, v2) => v1 + v2 },
+        'd', 'e'
+      ),
+      {a: 'de'},
+      `passes arguments to resolver function callbacks`
+    );
     st.end();
   });
 

--- a/tests/unit/mapper/insert.js
+++ b/tests/unit/mapper/insert.js
@@ -157,12 +157,18 @@ test('== Mapper - insert ==', t => {
     );
 
     const FnDefaults = Mapper.table('table').defaultAttributes({
-      default: () => 'default'
+      default: () => 'default',
+      other: attributes => attributes.value
     });
 
     st.queriesEqual(
-      FnDefaults.prepareInsert({}).toQueryBuilder(),
-      `insert into "table" ("default") values ('default')`
+      FnDefaults.prepareInsert({value: 5}).toQueryBuilder(),
+      `
+      insert into "table"
+        ("default", "other", "value")
+      values
+        ('default', 5, 5)
+      `
     );
 
     st.end();

--- a/tests/unit/mapper/update.js
+++ b/tests/unit/mapper/update.js
@@ -190,7 +190,7 @@ test('== Mapper - update ==', t => {
     st.queriesEqual(
       Defaults.prepareUpdate({ id: 1, value: 'value' }).toQueryBuilder(),
       `update "table" set "value" = 'value' where "id" = 1`,
-      'do not affect update query'
+      'does not affect update query'
     );
 
     st.end();
@@ -199,12 +199,13 @@ test('== Mapper - update ==', t => {
   t.test('Mapper.strictAttributes().prepareUpdate()', st => {
 
     const Strict = Mapper.table('table').strictAttributes({
-      strict: 'strict'
+      strict: 'strict',
+      other: attributes => attributes.id
     });
 
     st.queriesEqual(
       Strict.prepareUpdate({ id: 1, strict: 'overridden' }).toQueryBuilder(),
-      `update "table" set "strict" = 'strict' where "id" = 1`
+      `update "table" set "other" = 1, "strict" = 'strict' where "id" = 1`
     );
 
     const FnStrict = Mapper.table('table').strictAttributes({


### PR DESCRIPTION
Resolve any functions passed `defaultAttributes` and `strictAttributes` using the `attributes` object as an argument.

Closes #18