### PR TITLE
Add `FormatAttributes` plugin

### DIFF
--- a/src/mapper/key-conversion.js
+++ b/src/mapper/key-conversion.js
@@ -10,18 +10,10 @@ export default {
   attributeToColumn: identity,
 
   /** @protected */
-  columnsToAttributes(columns) {
-    return this.columnToAttribute !== identity
-      ? mapKeys(columns, (value, column) => this.columnToAttribute(column))
-      : columns;
-  },
+  columnsToAttributes: identity,
 
   /** @protected */
-  attributesToColumns(attributes) {
-    return this.attributeToColumn !== identity
-      ? mapKeys(attributes, (value, attr) => this.attributeToColumn(attr))
-      : attributes;
-  },
+  attributesToColumns: identity,
 
   /** @private */
   columnToTableColumn(column) {

--- a/src/plugins/CamelCase.js
+++ b/src/plugins/CamelCase.js
@@ -1,9 +1,10 @@
 import camelCase from 'lodash/camelCase';
 import snakeCase from 'lodash/snakeCase';
+import FormatAttributes from './FormatAttributes';
 
 export default function CamelCase() {
-  return {
+  return FormatAttributes({
     attributeToColumn: snakeCase,
     columnToAttribute: camelCase
-  };
+  });
 }

--- a/src/plugins/FormatAttributes.js
+++ b/src/plugins/FormatAttributes.js
@@ -1,0 +1,34 @@
+import memoize from 'lodash/memoize';
+import mapKeys from 'lodash/mapKeys';
+
+function FormatAttributes({ attributeToColumn, columnToAttribute }) {
+
+  return callSuper => ({
+
+    attributeToColumn: memoize(function(attribute) {
+      return attributeToColumn(
+        callSuper(this, 'attributeToColumn', attribute)
+      );
+    }),
+
+    columnToAttribute: memoize(function(column) {
+      return columnToAttribute(
+        callSuper(this, 'columnToAttribute', column)
+      );
+    }),
+
+    columnsToAttributes(columns) {
+      return mapKeys(columns, (value, column) =>
+        this.columnToAttribute(column)
+      );
+    },
+
+    attributesToColumns(attributes) {
+      return mapKeys(attributes, (value, attribute) =>
+        this.attributeToColumn(attribute)
+      );
+    }
+  });
+}
+
+export default FormatAttributes;

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,4 +1,5 @@
 import CamelCase from './CamelCase';
 import Timestamp from './Timestamp';
-export { CamelCase, Timestamp };
-export default { CamelCase, Timestamp };
+import FormatAttributes from './FormatAttributes';
+export { CamelCase, FormatAttributes, Timestamp };
+export default { CamelCase, FormatAttributes, Timestamp };


### PR DESCRIPTION
Helper plugin to override key conversion methods. Memoizes formatter functions.

`CamelCase` is implemented in terms of this plugin.