### PR TITLE
Automatically wrap string args `with` and `load`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "pg": "^4.4.3",
     "source-map-support": "^0.3.3",
     "tap-dot": "^1.0.0",
-    "tape": "^4.2.0",
+    "tape": "^4.5.1",
     "tape-catch": "^1.0.4"
   },
   "peerDependencies": {

--- a/readme.hbs
+++ b/readme.hbs
@@ -81,7 +81,7 @@ Records come back as plain objects. Example [`fetch`](#Mapper+fetch) response:
 ]
 ```
 
-Specialize an existing mapper express domain logic:
+Specialize an existing mapper target a subset of rows:
 
 ```js
 const Admins = Users.where('is_admin', true);
@@ -95,8 +95,8 @@ Admins.find(3).then(admin => {
 });
 ```
 
-Works when creating models too:
-TODO: _Make this actually work!_
+~Works when creating models too:~
+_This has not yet been implemented ([issue](https://github.com/rhys-vdw/atlas/issues/69))_
 
 ```js
 const heath = Admins.forge({ name: 'Heath' });
@@ -128,35 +128,25 @@ const Posts = Mapper.table('posts').relations({
 });
 ```
 
-Now using those relations:
+Now eager loading those relations:
 
 ```js
-// Use the `related` helper.
-const { related } = atlas;
-
-// Load up Annie and eager load relations.
-return Users.with(
-  related('groups'),
-  related('lastLogin'),
-  related('posts').query(query =>
-    query.orderBy('created_at', 'desc').limit(2)
-  ).as('recentPosts')
-).findBy('name', 'Annie').then(annie => {
-  render(annie);
-})
+return Users.with('groups', 'lastLogin', 'posts')
+  .findBy('name', 'Annie')
+  .then(annie => { console.log(util.inspect(annie)); });
 ```
 
-Relations get nested in the returned record:
+Relations get keyed by name in the returned record, eg:
 
 ```js
 {
-  id: 1,
+  id: 20,
   name: 'Annie',
   lastLogin: { user_id: 1, created_at: '2015-11-26' },
   groups: [
     { id: 20, name: 'Super Friends', _pivot_user_id: 1 },
   ],
-  recentPosts: [
+  posts: [
     { id: 120, author_id: 1, created_at: '2015-11-24',
       title: 'Hi', message: 'Hey there!' },
     { id: 110, author_id: 1, created_at: '2015-10-30',

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -152,4 +152,3 @@ export function isValidId(id) {
     : id != null;
   return result;
 }
-

--- a/src/atlas.js
+++ b/src/atlas.js
@@ -96,7 +96,7 @@ const createAtlas = (knex, registry) => {
  * const pg = Atlas(pgKnex, mapperRegistry);
  * const { related } = pg;
  *
- * pg('Product').with(related('sales', 'owners')).fetch().then(products =>
+ * pg('Product').with('sales', 'owners').fetch().then(products =>
  *   // Fetches and related records from PostgreSQL database.
  * ):
  * ```
@@ -261,7 +261,7 @@ export default function Atlas(knex, registry = createRegistry()) {
        * @param {Atlas} t
        *   An instance of `Atlas` connected to the transaction.
        * @param {Transaction} t.knex
-       *   The Knex.js `Transaction`instace.
+       *   The Knex.js `Transaction` instance.
        */
       transactionCallback(createAtlas(trx, registry))
     );

--- a/tests/integration/mapper/eager-loading.js
+++ b/tests/integration/mapper/eager-loading.js
@@ -79,7 +79,7 @@ export default function(atlas) {
         ),
 
         st.resolvesToDeep(
-          atlas('Actors').with(related('movies').with(related('director'))).find(2),
+          atlas('Actors').with(related('movies').with('director')).find(2),
           { id: 2, name: 'James Spader', movies: [
             { _pivot_actor_id: 2, id: 3, title: 'Stargate', director_id: 2,
               director: { id: 2, name: 'Roland Emmerich' }
@@ -90,7 +90,7 @@ export default function(atlas) {
 
         st.resolvesToDeep(
           atlas('Directors')
-          .with(related('movies').with(related('cast', 'director')))
+          .with(related('movies').with('cast', 'director'))
           .fetch(),
           [ { id: 1,
               name: 'John Carpenter',

--- a/tests/integration/mapper/relations-belongs-to-many.js
+++ b/tests/integration/mapper/relations-belongs-to-many.js
@@ -146,7 +146,7 @@ export default function(atlas) {
 
         return Promise.join(
           st.resolvesToDeep(
-            Users.load(related('groups')).into({ id: 1, name: 'dean' }),
+            Users.load('groups').into({ id: 1, name: 'dean' }),
             { id: 1, name: 'dean', groups: [
               { _pivot_user_id: 1, id: 10, name: `General` },
               { _pivot_user_id: 1, id: 11, name: `Balloon Enthusiasts` }
@@ -154,7 +154,7 @@ export default function(atlas) {
             'loads into single record'
           ),
           st.resolvesToDeep(
-            Users.load(related('groups')).into(sarah, baz), [
+            Users.load('groups').into(sarah, baz), [
               { id: 2, name: 'Sarah', groups: [
                 { _pivot_user_id: 2, id: 10, name: `General` },
                 { _pivot_user_id: 2, id: 12, name: `Off topic` }
@@ -167,7 +167,7 @@ export default function(atlas) {
 
           ),
           st.resolvesToDeep(
-            Users.load(related('groups')).into(dean, other), [
+            Users.load('groups').into(dean, other), [
               { id: 1, name: 'dean', groups: [
                 { _pivot_user_id: 1, id: 10, name: `General` },
                 { _pivot_user_id: 1, id: 11, name: `Balloon Enthusiasts` }
@@ -208,7 +208,7 @@ export default function(atlas) {
       ])).then(() => {
 
         return st.resolvesToDeep(
-          Users.query('orderBy', 'id').with(related('groups')).fetch(), [
+          Users.query('orderBy', 'id').with('groups').fetch(), [
             { id: 1, name: 'Dean', groups: [
               { _pivot_user_id: 1, id: 10, name: `General` },
               { _pivot_user_id: 1, id: 11, name: `Balloon Enthusiasts` }

--- a/tests/integration/mapper/relations-belongs-to.js
+++ b/tests/integration/mapper/relations-belongs-to.js
@@ -93,14 +93,14 @@ export default function(atlas) {
 
         return Promise.join(
           st.resolvesToDeep(
-            Posts.load(related('author')).into(deanA),
+            Posts.load('author').into(deanA),
             { id: 10, author_id: 1, message: `Dean's first post`, author:
               { id: 1, name: 'Dean' }
             },
             'loads into single record'
           ),
           st.resolvesToDeep(
-            Posts.load(related('author')).into(sarahA, barryA), [
+            Posts.load('author').into(sarahA, barryA), [
               { id: 12, author_id: 2, message: `Hello I'm Sarah`, author:
                 { id: 2, name: 'Sarah' }
               },
@@ -110,7 +110,7 @@ export default function(atlas) {
             ], 'loads into multiple records'
           ),
           st.resolvesToDeep(
-            Posts.load(related('author')).into(deanA, deanB), [
+            Posts.load('author').into(deanA, deanB), [
               { id: 10, author_id: 1, message: `Dean's first post`, author:
                 { id: 1, name: 'Dean' }
               },
@@ -120,7 +120,7 @@ export default function(atlas) {
             ], 'loads the same author into two records'
           ),
           st.resolvesToDeep(
-            Posts.load(related('author')).into(deanB, deletedAuthor), [
+            Posts.load('author').into(deanB, deletedAuthor), [
               { id: 13, author_id: 1, message: `Dean again`, author:
                 { id: 1, name: 'Dean' }
               },
@@ -128,7 +128,7 @@ export default function(atlas) {
             ], 'loads related into one record and null into another'
           ),
           st.resolvesToDeep(
-            Posts.load(related('author')).into(noAuthor),
+            Posts.load('author').into(noAuthor),
             { id: 15, author_id: null, message: `anonymous`, author: null },
             'loads relation as null when foreign key is null'
           )
@@ -161,7 +161,7 @@ export default function(atlas) {
       ])).then(() => {
 
         return st.resolvesToDeep(
-          Posts.with(related('author')).fetch(), [
+          Posts.with('author').fetch(), [
             { id: 10, author_id: 1, message: `Dean's first post` , author:
               { id: 1, name: 'Dean' }
             },

--- a/tests/integration/mapper/relations-has-many.js
+++ b/tests/integration/mapper/relations-has-many.js
@@ -102,7 +102,7 @@ export default function(atlas) {
 
         return Promise.join(
           st.resolvesToDeep(
-            Users.load(related('posts')).into(dean),
+            Users.load('posts').into(dean),
             { id: 1, name: 'dean', posts: [
                 { id: 10, author_id: 1, message: `Dean's first post` },
                 { id: 13, author_id: 1, message: `Dean again` },
@@ -110,7 +110,7 @@ export default function(atlas) {
             'loads into single record'
           ),
           st.resolvesToDeep(
-            Users.load(related('posts')).into(sarah, baz), [
+            Users.load('posts').into(sarah, baz), [
               { id: 2, name: 'Sarah', posts: [
                 { id: 12, author_id: 2, message: `Hello I'm Sarah` },
               ] },
@@ -121,7 +121,7 @@ export default function(atlas) {
             ], 'loads into multiple records'
           ),
           st.resolvesToDeep(
-            Users.load(related('posts')).into(dean, other), [
+            Users.load('posts').into(dean, other), [
               { id: 1, name: 'dean', posts: [
                 { id: 10, author_id: 1, message: `Dean's first post` },
                 { id: 13, author_id: 1, message: `Dean again` },
@@ -157,7 +157,7 @@ export default function(atlas) {
       ])).then(() => {
 
         return st.resolvesToDeep(
-          Users.query('orderBy', 'id').with(related('posts')).fetch(), [
+          Users.query('orderBy', 'id').with('posts').fetch(), [
             { id: 1, name: 'Dean', posts: [
                 { id: 10, author_id: 1, message: `Dean's first post` },
                 { id: 13, author_id: 1, message: `Dean again` },

--- a/tests/integration/mapper/relations-has-one.js
+++ b/tests/integration/mapper/relations-has-one.js
@@ -103,14 +103,14 @@ export default function(atlas) {
 
         return Promise.join(
           st.resolvesToDeep(
-            Users.load(related('avatar')).into(dean),
+            Users.load('avatar').into(dean),
             { id: 1, name: 'dean', avatar:
               { id: 10, user_id: 1, image_path: './dean.jpg' }
             },
             'loads into single record'
           ),
           st.resolvesToDeep(
-            Users.load(related('avatar')).into(sarah, baz), [
+            Users.load('avatar').into(sarah, baz), [
               { id: 2, name: 'Sarah', avatar:
                 { id: 12, user_id: 2, image_path: './sarah.jpg' }
               }, { id: 3, name: 'Baz', avatar:
@@ -119,7 +119,7 @@ export default function(atlas) {
             ], 'loads into multiple records'
           ),
           st.resolvesToDeep(
-            Users.load(related('avatar')).into(dean, other), [
+            Users.load('avatar').into(dean, other), [
               { id: 1, name: 'dean', avatar:
                 { id: 10, user_id: 1, image_path: './dean.jpg' }
               }, { id: 4, name: 'Other', avatar: null }
@@ -151,7 +151,7 @@ export default function(atlas) {
       ])).then(() => {
 
         return st.resolvesToDeep(
-          Users.with(related('avatar')).fetch(), [
+          Users.with('avatar').fetch(), [
             { id: 1, name: 'Dean', avatar:
               { id: 10, user_id: 1, image_path: './dean.jpg' }
             },

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -3,5 +3,6 @@ import './atlas';
 import './immutable-base';
 import './mapper';
 import './registry';
+import './related';
 import './relations';
 import './plugins';

--- a/tests/unit/related.js
+++ b/tests/unit/related.js
@@ -1,0 +1,53 @@
+import test from 'tape';
+
+import Related, { related } from '../../lib/related';
+import BelongsTo from '../../lib/relations/belongs-to';
+import Mapper from '../../lib/mapper/index';
+
+test('Arguments', t => {
+
+  t.test('related() - invalid', st => {
+
+    st.throws(() => related(), TypeError);
+    st.throws(() => related(null), TypeError);
+    st.throws(() => related(5), TypeError);
+
+    st.end();
+  });
+
+  t.test('related(string)', st => {
+
+    const result = related('hello');
+
+    st.ok(result instanceof Related, 'returns instance of `Related`');
+
+    st.equal(related('hello').requireState('name'), 'hello', 'assigns name');
+
+    st.end();
+  });
+
+  t.test('related(Related)', st => {
+    const self = new Related();
+    st.equal(related(self), self, 'returns self');
+
+    st.end();
+  });
+
+  t.test('related(BelongsTo)', st => {
+
+    const Records = Mapper.table('records');
+    const recordRelation = new BelongsTo(Records, Records);
+
+    const result = related(recordRelation);
+
+    st.ok(result instanceof Related, 'returns instance of `Related`');
+
+    st.equal(
+      result.getRelation(), recordRelation,
+      'sets correct relation'
+    );
+
+    st.end();
+  });
+
+});


### PR DESCRIPTION
Simplify eager loading API by allowing plain strings to be passed to:

`Mapper#with`
`Mapper#load`
`Related#with`

Closes #70