### PR TITLE
Add `related.ALL` and `related.NONE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1626,7 +1626,7 @@ Posts.with('author').fetch().then(postsWithAuthor => {
 
 | Param | Type | Description |
 | --- | --- | --- |
-| ...related | <code>[Related](#Related)</code> &#124; <code>string</code> &#124; <code>[Array.&lt;Related&gt;](#Related)</code> &#124; <code>Array.&lt;string&gt;</code> | One or more Related instances or relation names. |
+| ...related | <code>[Related](#Related)</code> &#124; <code>string</code> &#124; <code>[ALL](#related.ALL)</code> | One or more Related instances or relation names. Or [ALL](#related.ALL)   to select all registered relations. |
 
 
 -
@@ -2111,7 +2111,7 @@ atlas('Users').with(
 
 | Param | Type | Description |
 | --- | --- | --- |
-| ...related | <code>[Related](#Related)</code> &#124; <code>string</code> &#124; <code>[Array.&lt;Related&gt;](#Related)</code> &#124; <code>Array.&lt;string&gt;</code> | One or more Related instances or relation names. |
+| ...related | <code>[Related](#Related)</code> &#124; <code>string</code> &#124; <code>[ALL](#related.ALL)</code> &#124; <code>[NONE](#related.NONE)</code> | One or more `Related` instances or relation names. Pass   [ALL](#related.ALL) or [NONE](#related.NONE) to select all relations or   clear any previously specific relations. |
 
 
 -
@@ -2749,6 +2749,27 @@ Authors.where({ surname: 'Herbert' }).with(
 | Param | Type | Description |
 | --- | --- | --- |
 | relationName | <code>string</code> &#124; <code>Relation</code> | The name of a relation registered with [relations](#Mapper+relations) or a   [Relation](Relation) instance. |
+
+
+* [related(relationName)](#related) ⇒ <code>[Related](#Related)</code>
+    * [.ALL](#related.ALL)
+    * [.NONE](#related.NONE)
+
+
+-
+
+<a name="related.ALL"></a>
+
+### related.ALL
+Select all relations
+
+
+-
+
+<a name="related.NONE"></a>
+
+### related.NONE
+Clear all relations
 
 
 -

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,3 +2,5 @@ export const PIVOT_PREFIX = '_pivot_';
 export const PIVOT_ALIAS = 'pivot';
 export const MAPPER_SENTINEL = '__MAPPER__';
 export const RELATED_SENTINEL = '__RELATED__';
+export const ALL = '__ALL__';
+export const NONE = '__NONE__';

--- a/src/mapper/relations.js
+++ b/src/mapper/relations.js
@@ -1,7 +1,10 @@
 import { inspect } from 'util';
-import { keys as objectKeys, reject, isFunction, isString } from 'lodash';
+import {
+  keys as objectKeys, reject, isEmpty, isFunction, isString
+} from 'lodash';
 import { normalizeRelated, isRelated } from '../related';
 import EagerLoader from '../eager-loader';
+import { ALL, NONE } from '../constants';
 
 export default {
 
@@ -227,12 +230,25 @@ export default {
    *
    * @todo Support saving relations.
    *
-   * @param {...(Related|string|Related[]|string[])} related
-   *   One or more Related instances or relation names.
+   * @param {...(Related|string|related.ALL|related.NONE)} related
+   *   One or more `Related` instances or relation names. Pass
+   *   {@link related.ALL} or {@link related.NONE} to select all relations or
+   *   clear any previously specific relations.
    * @returns {Mapper}
    *   Mapper configured to eager load related records.
    */
   with(...related) {
+
+    if (related[0] === ALL) {
+      return this.setState({
+        related: normalizeRelated(this.getRelationNames())
+      });
+    }
+
+    if (related[0] === NONE) {
+      const previous = this.state.related;
+      return isEmpty(previous) ? this : this.setState({ related: [] });
+    }
 
     const flattened = normalizeRelated(...related);
 
@@ -292,13 +308,21 @@ export default {
    *
    * *See `Mapper.relations()` for example of how to set up this schema.*
    *
-   * @param {...(Related|string|Related[]|string[])} related
-   *   One or more Related instances or relation names.
+   * @param {...(Related|string|related.ALL)} related
+   *   One or more Related instances or relation names. Or {@link related.ALL}
+   *   to select all registered relations.
    * @returns {EagerLoader}
    *   An EagerLoader instance configured to load the given relations into
    *   records.
    */
   load(...related) {
+
+    if (related[0] === ALL) {
+      related = this.getRelationNames();
+    } else if (related[0] === NONE) {
+      related = [];
+    }
+
     return new EagerLoader(this, normalizeRelated(...related));
   }
 

--- a/src/related.js
+++ b/src/related.js
@@ -2,7 +2,7 @@ import { inspect } from 'util';
 import { flatten, isFunction, isString } from 'lodash';
 
 import ImmutableBase from './immutable-base';
-import { RELATED_SENTINEL } from './constants';
+import { ALL, NONE, RELATED_SENTINEL } from './constants';
 
 export function isRelated(maybeRelated) {
   return !!(maybeRelated && maybeRelated[RELATED_SENTINEL]);
@@ -335,6 +335,18 @@ function toRelated(relationName) {
     `got ${inspect(relationName)}`
   );
 }
+
+/**
+ * Select all relations
+ * @constant
+ */
+toRelated.ALL = ALL;
+
+/**
+ * Clear all relations
+ * @constant
+ */
+toRelated.NONE = NONE;
 
 /**
  * @private

--- a/tests/unit/mapper/relations.js
+++ b/tests/unit/mapper/relations.js
@@ -1,29 +1,103 @@
 import test from 'tape';
 import Mapper from '../../../lib/mapper';
 import Atlas from '../../../lib/atlas';
+import { related } from '../../../lib/related';
 
-test('Mapper - relations unit test', t => {
-  t.test('Mapper#relations', t => {
+test('Mapper#relations', t => {
 
-    const atlas = Atlas();
-    const Things = Mapper.table('things');
-    const ownedThing = o => o.hasOne(Things)
-    const Owner = Mapper.table('owners').relations({
-      hasThing: ownedThing
-    });
-
-    t.notEqual(Owner, Mapper, 'copies immutable Mapper');
-
-    t.deepEqual(
-      Owner.requireState('relations'),
-      { hasThing: ownedThing },
-      'Correctly assigns relations'
-    );
-
-    const hasThing = Owner.getRelation('hasThing');
-
-    t.equal(hasThing.Self, Owner, 'correctly assigned self');
-
-    t.end();
+  const atlas = Atlas();
+  const Things = Mapper.table('things');
+  const ownedThing = o => o.hasOne(Things)
+  const Owner = Mapper.table('owners').relations({
+    hasThing: ownedThing
   });
+
+  t.notEqual(Owner, Mapper, 'copies immutable Mapper');
+
+  t.deepEqual(
+    Owner.requireState('relations'),
+    { hasThing: ownedThing },
+    'Correctly assigns relations'
+  );
+
+  const hasThing = Owner.getRelation('hasThing');
+
+  t.equal(hasThing.Self, Owner, 'correctly assigned self');
+
+  t.end();
+});
+
+test('Mapper#with(ALL)', t => {
+
+  const relations = [];
+  const Records = Mapper.table('records').relations({
+    a: m => relations[0] = m.belongsTo(Records),
+    b: m => relations[1] = m.belongsTo(Records),
+    c: m => relations[2] = m.belongsTo(Records),
+    d: m => relations[3] = m.belongsTo(Records),
+  }).with(related.ALL);
+
+  const relatedInstances = Records.requireState('related');
+
+  t.equal(relatedInstances[0].name(), 'a');
+  t.equal(relatedInstances[1].name(), 'b');
+  t.equal(relatedInstances[2].name(), 'c');
+  t.equal(relatedInstances[3].name(), 'd');
+
+  t.equal(relatedInstances[0].getRelation(Records), relations[0]);
+  t.equal(relatedInstances[1].getRelation(Records), relations[1]);
+  t.equal(relatedInstances[2].getRelation(Records), relations[2]);
+  t.equal(relatedInstances[3].getRelation(Records), relations[3]);
+
+  t.end();
+});
+
+test('Mapper#with(NONE)', t => {
+
+  const relations = [];
+  const Records = Mapper.table('records').relations({
+    a: m => relations[0] = m.belongsTo(Records),
+    b: m => relations[1] = m.belongsTo(Records),
+    c: m => relations[2] = m.belongsTo(Records),
+    d: m => relations[3] = m.belongsTo(Records),
+  }).with('a', 'b', 'c', 'd');
+
+  const relatedInstances = Records.with(related.NONE).requireState('related');
+
+  t.deepEqual(relatedInstances, []);
+
+  t.end();
+});
+
+test('Mapper#load(ALL)', t => {
+
+  const relations = [];
+  const Records = Mapper.table('records').relations({
+    a: m => relations[0] = m.belongsTo(Records),
+    b: m => relations[1] = m.belongsTo(Records),
+  });
+
+  const { relatedList } = Records.load(related.ALL);
+
+  t.equal(relatedList[0].name(), 'a');
+  t.equal(relatedList[1].name(), 'b');
+
+  t.equal(relatedList[0].getRelation(Records), relations[0]);
+  t.equal(relatedList[1].getRelation(Records), relations[1]);
+
+  t.end();
+});
+
+test('Mapper#load(NONE)', t => {
+
+  const relations = [];
+  const Records = Mapper.table('records').relations({
+    a: m => relations[0] = m.belongsTo(Records),
+    b: m => relations[1] = m.belongsTo(Records),
+  });
+
+  const { relatedList } = Records.load(related.NONE);
+
+  t.deepEqual(relatedList, []);
+  t.end();
 });


### PR DESCRIPTION
Add support to auto select all relations, or clear any previously selected relations.

Closes #71 